### PR TITLE
 Add synchronize operation

### DIFF
--- a/Database/KyotoCabinet/DB/Tree.hs
+++ b/Database/KyotoCabinet/DB/Tree.hs
@@ -49,6 +49,7 @@ data TreeOptions = TreeOptions { alignmentPow :: Maybe Int8
                                , pageSize :: Maybe Int64
                                , comparator :: Maybe Comparator
                                , pageCacheSize :: Maybe Int64
+                               , mmapSize :: Maybe Int64
                                }
                  deriving (Show, Read, Eq, Ord)
 
@@ -64,6 +65,7 @@ defaultTreeOptions = TreeOptions { alignmentPow = Nothing
                                  , pageSize = Nothing
                                  , comparator = Nothing
                                  , pageCacheSize = Nothing
+                                 , mmapSize = Nothing
                                  }
 
 toTuningOptions :: TreeOptions -> [TuningOption]
@@ -78,10 +80,12 @@ toTuningOptions TreeOptions { alignmentPow = ap
                             , pageSize = ps
                             , comparator = cmprtr
                             , pageCacheSize = pcs
+                            , mmapSize = mmapsz
                             } =
   mtl AlignmentPow ap ++ mtl FreePoolPow fp ++ map Options os ++ mtl Buckets bs ++
   mtl MaxSize ms ++ mtl DefragInterval di ++ mtl Compressor cmp ++ mtl CipherKey key ++
-  mtl PageSize ps ++ mtl Comparator cmprtr ++ mtl PageCacheSize pcs
+  mtl PageSize ps ++ mtl Comparator cmprtr ++ mtl PageCacheSize pcs ++
+  mtl MMapSize mmapsz
   where
     mtl f = maybeToList .  fmap f
 

--- a/Database/KyotoCabinet/Foreign.hsc
+++ b/Database/KyotoCabinet/Foreign.hsc
@@ -335,6 +335,12 @@ foreign import ccall "kclangc.h kcdbgetbulk"
 
 -- int32_t kcdbsync (KCDB *db, int32_t hard, KCFILEPROC proc, void *opq)
 
+kcdbsync:: Ptr KCDB -> Bool -> IO ()
+kcdbsync db hard =
+  kcdbsync' db (boolToInt hard) nullPtr nullPtr >>= handleBoolResult db "kcdbsync"
+foreign import ccall "kclangc.h kcdbsync"
+  kcdbsync' :: Ptr KCDB -> Int32 -> Ptr () -> Ptr () -> IO Int32
+
 -- int32_t kcdboccupy (KCDB *db, int32_t writable, KCFILEPROC proc, void *opq)
 
 kcdbcopy :: Ptr KCDB -> String -> IO ()

--- a/Database/KyotoCabinet/Operations.hs
+++ b/Database/KyotoCabinet/Operations.hs
@@ -58,6 +58,8 @@ module Database.KyotoCabinet.Operations
        , MergeMode (..)
        , GenericDB (..)
        , merge
+         -- ** Flushing
+       , synchronize
 
          -- * Cursors
        , Cursor
@@ -212,6 +214,11 @@ merge db dbs mode = go dbs [] $ \kcdbs -> withFor2 (unDB . getDB) kcdbmerge db k
     go [] kcdbs f = f $ reverse kcdbs
     go ((GenericDB db') : dbs') kcdbs f =
       withForeignPtr (unDB . getDB $ db') $ \kcdb -> go dbs' (kcdb : kcdbs) f
+
+-------------------------------------------------------------------------------
+
+synchronize :: WithDB db => db -> Bool -> IO ()
+synchronize db hard = withFor1 (unDB . getDB) kcdbsync db hard
 
 -------------------------------------------------------------------------------
 

--- a/kyotocabinet.cabal
+++ b/kyotocabinet.cabal
@@ -3,7 +3,6 @@ Name:                   kyotocabinet
 Version:                0.1.4
 Author:                 Francesco Mazzoli (f@mazzo.li)
 Maintainer:             Francesco Mazzoli (f@mazzo.li)
-Build-Type:             Simple
 License:                BSD3
 License-File:           LICENSE
 Build-Type:             Simple


### PR DESCRIPTION
This adds support for the `sync` operation, which can be useful to control memory usage in write-heavy workloads.